### PR TITLE
Fix/Add assembly item because of modified assembly in  AssetWorkflow.Addressables

### DIFF
--- a/Assets/Tests/Runtime/Extreal.Integration.Assets.Addressables.Test.asmdef
+++ b/Assets/Tests/Runtime/Extreal.Integration.Assets.Addressables.Test.asmdef
@@ -5,6 +5,7 @@
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
         "Extreal.Integration.AssetWorkflow.Addressables",
+        "Extreal.Integration.AssetWorkflow.Addressables.Custom.ResourceProviders",
         "Extreal.Core.Logging",
         "Extreal.Core.Common",
         "Unity.Addressables",


### PR DESCRIPTION
# 何の変更を加えましたか？
https://github.com/extreal-dev/Extreal.Integration.AssetWorkflow.Addressables/pull/4 でアセンブリ修正が入ったため、それに合わせてテスト側のアセンブリも修正した

# 確認したこと
・Readmeのテストが成功したことを全部確認した
　　・テストはhttps://github.com/extreal-dev/Extreal.Integration.AssetWorkflow.Addressables/pull/4 　の修正に合わせて確認した
・静的解析に警告がないことを確認した